### PR TITLE
fix: don't include `css-vars-ponyfill` chunk if not enabled

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -35,9 +35,10 @@ export default defineNuxtModule<ModuleOptions>({
     },
   },
   async setup(moduleOptions, nuxt) {
-    nuxt.options.alias['#cookie-control/set-vars'] = moduleOptions.isCssPonyfillEnabled
-      ? resolve(runtimeDir, 'set-vars/ponyfill')
-      : resolve(runtimeDir, 'set-vars/native')
+    nuxt.options.alias['#cookie-control/set-vars'] =
+      moduleOptions.isCssPonyfillEnabled
+        ? resolve(runtimeDir, 'set-vars/ponyfill')
+        : resolve(runtimeDir, 'set-vars/native')
 
     nuxt.options.alias['#cookie-control'] = runtimeDir
     nuxt.options.build.transpile.push(runtimeDir)

--- a/src/module.ts
+++ b/src/module.ts
@@ -35,6 +35,10 @@ export default defineNuxtModule<ModuleOptions>({
     },
   },
   async setup(moduleOptions, nuxt) {
+    nuxt.options.alias['#cookie-control/set-vars'] = moduleOptions.isCssPonyfillEnabled
+      ? resolve(runtimeDir, 'set-vars/ponyfill')
+      : resolve(runtimeDir, 'set-vars/native')
+
     nuxt.options.alias['#cookie-control'] = runtimeDir
     nuxt.options.build.transpile.push(runtimeDir)
 

--- a/src/runtime/components/CookieControl.vue
+++ b/src/runtime/components/CookieControl.vue
@@ -196,6 +196,7 @@ import {
   setCookie,
   resolveTranslatable,
 } from '../methods'
+import setCSSVariables from '#cookie-control/set-vars'
 
 import { useCookieControl } from '#imports'
 
@@ -312,7 +313,7 @@ const toggleLabel = ($event: KeyboardEvent) => {
 }
 
 // lifecycle
-onBeforeMount(async () => {
+onBeforeMount(() => {
   if (moduleOptions.colors) {
     const variables: Record<string, any> = {}
 
@@ -320,18 +321,7 @@ onBeforeMount(async () => {
       variables[`cookie-control-${key}`] = `${moduleOptions.colors[key]}`
     }
 
-    if (moduleOptions.isCssPonyfillEnabled) {
-      const module = await import('css-vars-ponyfill')
-      const cssVars = module.default
-      cssVars({ variables })
-    } else {
-      for (const cssVar in variables) {
-        document.documentElement.style.setProperty(
-          `--${cssVar}`,
-          variables[cssVar]
-        )
-      }
-    }
+    setCSSVariables(variables)
   }
 
   if (

--- a/src/runtime/components/CookieControl.vue
+++ b/src/runtime/components/CookieControl.vue
@@ -196,7 +196,7 @@ import {
   setCookie,
   resolveTranslatable,
 } from '../methods'
-import setCSSVariables from '#cookie-control/set-vars'
+import setCssVariables from '#cookie-control/set-vars'
 
 import { useCookieControl } from '#imports'
 
@@ -321,7 +321,7 @@ onBeforeMount(() => {
       variables[`cookie-control-${key}`] = `${moduleOptions.colors[key]}`
     }
 
-    setCSSVariables(variables)
+    setCssVariables(variables)
   }
 
   if (

--- a/src/runtime/set-vars/native.ts
+++ b/src/runtime/set-vars/native.ts
@@ -1,0 +1,5 @@
+export default function (variables: Record<string, string>) {
+  for (const cssVar in variables) {
+    document.documentElement.style.setProperty(`--${cssVar}`, variables[cssVar])
+  }
+}

--- a/src/runtime/set-vars/ponyfill.ts
+++ b/src/runtime/set-vars/ponyfill.ts
@@ -1,0 +1,5 @@
+import cssVars from 'css-vars-ponyfill'
+
+export default function (variables: Record<string, string>) {
+  cssVars({ variables })
+}


### PR DESCRIPTION
### 📚 Description

This is how you would ensure that you don't accidentally create a chunk if the user doesn't want the feature enabled. Accessing `moduleOptions` isn't ideal because it's not static enough for rollup or vite to _know_ the value exists and never changes, and therefore be able to tree-shake out the contents of one-half of the if/else clause. So instead we can conditionally provide a helper file based on what the user option is.

Resolves #37.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commmits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format
- [x] The PR's title follows the Conventional Commit format
