### PR TITLE
ci: reenable mac and windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest] # macos-latest, windows-latest temporarily disabled (https://github.com/nuxt/framework/issues/8461)
+        os: [macos-latest, ubuntu-latest, windows-latest]
         node: [19]
 
     steps:

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,4 +1,5 @@
 import { resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
 
 import {
   defineNuxtModule,
@@ -109,8 +110,9 @@ const loadLocales = async (moduleOptions: ModuleOptions) => {
 
   for (const locale of locales) {
     const text = await import(
-      await resolvePath(resolve(runtimeDir, 'locale', locale))
-    ).then((r: any) => r.default || r)
+      pathToFileURL(await resolvePath(resolve(runtimeDir, 'locale', locale)))
+        .href
+    ).then((r) => r.default || r)
 
     if (!text) throw new Error(`Could not import text for locale ${locale}`)
 


### PR DESCRIPTION
### 📚 Description

Reenable ci for mac and windows.
Resolves #14.

### 📝 Checklist

- [x] All commits follow the Conventional Commit format
- [x] The PR's title follows the Conventional Commit format
