### PR TITLE
feat(modal): close on click outside

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ if (cookieControl.cookiesEnabledIds.value.includes('google-analytics')) {
 // 'top-left', 'top-right', 'top-full', 'bottom-left', 'bottom-right', 'bottom-full'
 barPosition: 'bottom-full',
 
+// Switch to toggle the behaviour on clicking the overlay outside the configuration modal.
+closeModalOnClickOutside: true,
+
 // Component colors.
 // If you want to disable colors set colors property to false.
 colors: {

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ if (cookieControl.cookiesEnabledIds.value.includes('google-analytics')) {
 // 'top-left', 'top-right', 'top-full', 'bottom-left', 'bottom-right', 'bottom-full'
 barPosition: 'bottom-full',
 
-// Switch to toggle the behaviour on clicking the overlay outside the configuration modal.
+// Switch to toggle if clicking the overlay outside the configuration modal closes the modal.
 closeModalOnClickOutside: true,
 
 // Component colors.

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -14,6 +14,7 @@ export default defineNuxtConfig({
     colors: {
       checkboxActiveBackground: '#00A34A', // text-green-600
     },
+    closeModalOnClickOutside: true,
     cookies: {
       necessary: [
         {

--- a/src/runtime/components/CookieControl.vue
+++ b/src/runtime/components/CookieControl.vue
@@ -240,12 +240,6 @@ const accept = () => {
     cookiesOptionalEnabled: moduleOptions.cookies.optional,
   })
 }
-const decline = () => {
-  setCookies({
-    isConsentGiven: true,
-    cookiesOptionalEnabled: moduleOptions.cookies.necessary,
-  })
-}
 const acceptPartial = () => {
   const localCookiesEnabledIds = getCookieIds(localCookiesEnabled.value)
 
@@ -257,22 +251,17 @@ const acceptPartial = () => {
     ].filter((cookie) => localCookiesEnabledIds.includes(getCookieId(cookie))),
   })
 }
+const decline = () => {
+  setCookies({
+    isConsentGiven: true,
+    cookiesOptionalEnabled: moduleOptions.cookies.necessary,
+  })
+}
 const declineAll = () => {
   setCookies({
     isConsentGiven: false,
     cookiesOptionalEnabled: [],
   })
-}
-const toogleCookie = (cookie: Cookie) => {
-  const cookieIndex = getCookieIds(localCookiesEnabled.value).indexOf(
-    getCookieId(cookie)
-  )
-
-  if (cookieIndex < 0) {
-    localCookiesEnabled.value.push(cookie)
-  } else {
-    localCookiesEnabled.value.splice(cookieIndex, 1)
-  }
 }
 const getDescription = (description: Translatable) =>
   `${
@@ -316,6 +305,17 @@ const toggleButton = ($event: MouseEvent) => {
     ($event.target as HTMLButtonElement | null)
       ?.nextSibling as HTMLLabelElement | null
   )?.click()
+}
+const toogleCookie = (cookie: Cookie) => {
+  const cookieIndex = getCookieIds(localCookiesEnabled.value).indexOf(
+    getCookieId(cookie)
+  )
+
+  if (cookieIndex < 0) {
+    localCookiesEnabled.value.push(cookie)
+  } else {
+    localCookiesEnabled.value.splice(cookieIndex, 1)
+  }
 }
 const toggleLabel = ($event: KeyboardEvent) => {
   if ($event.key === ' ') ($event.target as HTMLLabelElement | null)?.click()

--- a/src/runtime/components/CookieControl.vue
+++ b/src/runtime/components/CookieControl.vue
@@ -46,7 +46,10 @@
         <div
           v-if="isModalActive"
           class="cookieControl__Modal"
-          v-on="moduleOptions.closeModalOnClickOutside ? { click: () => isModalActive = false } : {}"
+          @click.self="
+            moduleOptions.closeModalOnClickOutside &&
+              (() => (isModalActive = false))()
+          "
         >
           <p
             v-if="isSaved"

--- a/src/runtime/components/CookieControl.vue
+++ b/src/runtime/components/CookieControl.vue
@@ -46,10 +46,7 @@
         <div
           v-if="isModalActive"
           class="cookieControl__Modal"
-          @click.self="
-            moduleOptions.closeModalOnClickOutside &&
-              (() => (isModalActive = false))()
-          "
+          @click.self="onModalClick"
         >
           <p
             v-if="isSaved"
@@ -288,6 +285,11 @@ const getName = (name: Translatable) => {
 }
 const init = () => {
   expires.setTime(expires.getTime() + moduleOptions.cookieExpiryOffsetMs)
+}
+const onModalClick = () => {
+  if (moduleOptions.closeModalOnClickOutside) {
+    isModalActive.value = false
+  }
 }
 const setCookies = ({
   cookiesOptionalEnabled: cookiesOptionalEnabledNew,

--- a/src/runtime/components/CookieControl.vue
+++ b/src/runtime/components/CookieControl.vue
@@ -43,7 +43,11 @@
         </svg>
       </button>
       <transition name="cookieControl__Modal">
-        <div v-if="isModalActive" class="cookieControl__Modal">
+        <div
+          v-if="isModalActive"
+          class="cookieControl__Modal"
+          v-on="moduleOptions.closeModalOnClickOutside ? { click: () => isModalActive = false } : {}"
+        >
           <p
             v-if="isSaved"
             class="cookieControl__ModalUnsaved"

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -72,6 +72,7 @@ export interface ModuleOptions {
     | 'bottom-left'
     | 'bottom-right'
     | 'bottom-full'
+  closeModalOnClickOutside: boolean;
   colors: false | Record<string, any>
   cookieExpiryOffsetMs: number
   cookieNameCookiesEnabledIds: string
@@ -94,6 +95,7 @@ export interface ModuleOptions {
 
 export const DEFAULTS: Required<ModuleOptions> = {
   barPosition: 'bottom-full',
+  closeModalOnClickOutside: false,
   colors: {
     barBackground: '#000',
     barButtonBackground: '#fff',

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -72,7 +72,7 @@ export interface ModuleOptions {
     | 'bottom-left'
     | 'bottom-right'
     | 'bottom-full'
-  closeModalOnClickOutside: boolean;
+  closeModalOnClickOutside: boolean
   colors: false | Record<string, any>
   cookieExpiryOffsetMs: number
   cookieNameCookiesEnabledIds: string


### PR DESCRIPTION
### 📚 Description
This PR adds a feature: click outside the modal content frame to close the modal. It also adds the option `closeModalOnClickOutside` to ModuleOptions.
`closeModalOnClickOutside` default to `false`. To activate this feature, set the new option to `true` in `nuxt.config.ts`
```ts
  ...
  cookieControl: {
    closeModalOnClickOutside: true,
   ...
  },
  ...
```
Resolves #85 
<!--
  Describe your changes in detail.
  Why is this change required? What problem does it solve?
  If it resolves an open issue, please link to the issue here. For example "Resolves #1337"
-->

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format
- [x] The PR's title follows the Conventional Commit format
