### PR TITLE
fix(cookie-control): remove `defineExpose` import

### DIFF
--- a/src/runtime/components/CookieControl.vue
+++ b/src/runtime/components/CookieControl.vue
@@ -190,7 +190,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onBeforeMount, watch, defineExpose } from 'vue'
+import { ref, computed, onBeforeMount, watch } from 'vue'
 
 import { Cookie, CookieType, Locale, Translatable } from '../types'
 import {


### PR DESCRIPTION
### 📚 Description

Remove `defineExpose` import as it's a compiler macro that's auto-imported.

### 📝 Checklist

- [x] All commits follow the Conventional Commit format
- [x] The PR's title follows the Conventional Commit format
