### PR TITLE
feat!: allow to configure cookie options

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,11 @@ cookieExpiryOffsetMs: 1000 * 60 * 60 * 24 * 365, // one year
 cookieNameIsConsentGiven: 'ncc_c',
 cookieNameCookiesEnabledIds: 'ncc_e',
 
+// Options to pass to nuxt's useCookie
+cookieOptions: {
+  path: '/',
+}
+
 // Switch to toggle the "accept necessary" button.
 isAcceptNecessaryButtonEnabled: true
 
@@ -176,10 +181,6 @@ isIframeBlocked: false,
 
 // Switch to toggle the modal being shown right away, requiring a user's decision.
 isModalForced: false,
-
-// The domain to set cookies on.
-// This is useful in case you have subdomains (shop.yourdomain.com)
-domain: 'yourdomain.com',
 
 // The locales to include.
 locales: ['en'],

--- a/src/runtime/components/CookieControl.vue
+++ b/src/runtime/components/CookieControl.vue
@@ -196,7 +196,6 @@ import {
   getCookieId,
   getCookieIds,
   removeCookie,
-  setCookie,
   resolveTranslatable,
 } from '../methods'
 import setCssVariables from '#cookie-control/set-vars'
@@ -219,12 +218,20 @@ const {
 } = useCookieControl()
 
 // data
-const expires = new Date()
+const expires = new Date(Date.now() + moduleOptions.cookieExpiryOffsetMs)
 const localCookiesEnabled = ref([...(cookiesEnabled.value || [])])
 const allCookieIdsString = getAllCookieIdsString(moduleOptions)
-const cookieIsConsentGiven = useCookie(moduleOptions.cookieNameIsConsentGiven)
+const cookieIsConsentGiven = useCookie(moduleOptions.cookieNameIsConsentGiven, {
+  expires,
+  ...moduleOptions.cookieOptions,
+})
+
 const cookieCookiesEnabledIds = useCookie(
-  moduleOptions.cookieNameCookiesEnabledIds
+  moduleOptions.cookieNameCookiesEnabledIds,
+  {
+    expires,
+    ...moduleOptions.cookieOptions,
+  }
 )
 
 // computations
@@ -274,9 +281,6 @@ const getName = (name: Translatable) => {
   return name === 'functional'
     ? localeStrings.value?.cookiesFunctional
     : resolveTranslatable(name, props.locale)
-}
-const init = () => {
-  expires.setTime(expires.getTime() + moduleOptions.cookieExpiryOffsetMs)
 }
 const onModalClick = () => {
   if (moduleOptions.closeModalOnClickOutside) {
@@ -358,13 +362,7 @@ watch(
     localCookiesEnabled.value = [...(current || [])]
 
     if (isConsentGiven.value) {
-      setCookie(
-        moduleOptions.cookieNameCookiesEnabledIds,
-        getCookieIds(current || []).join('|'),
-        {
-          expires,
-        }
-      )
+      cookieCookiesEnabledIds.value = getCookieIds(current || []).join('|')
 
       for (const cookieEnabled of current || []) {
         if (!cookieEnabled.src) continue
@@ -406,13 +404,7 @@ watch(isConsentGiven, (current, _previous) => {
   if (current === undefined) {
     cookieIsConsentGiven.value = undefined
   } else {
-    setCookie(
-      moduleOptions.cookieNameIsConsentGiven,
-      current ? allCookieIdsString : '0',
-      {
-        expires,
-      }
-    )
+    cookieIsConsentGiven.value = current ? allCookieIdsString : '0'
   }
 })
 
@@ -421,7 +413,4 @@ defineExpose({
   acceptPartial,
   decline,
 })
-
-// initialization
-init()
 </script>

--- a/src/runtime/methods.ts
+++ b/src/runtime/methods.ts
@@ -1,5 +1,5 @@
 import slugify from '@sindresorhus/slugify'
-import { serialize, type CookieSerializeOptions } from 'cookie-es'
+import { serialize } from 'cookie-es'
 
 import { LOCALE_DEFAULT } from './constants'
 import { Cookie, ModuleOptions, Translatable } from './types'
@@ -35,16 +35,6 @@ export const resolveTranslatable = (
 
   return result
 }
-
-export const setCookie = (
-  name: string,
-  value: string,
-  options: CookieSerializeOptions
-) =>
-  (document.cookie = serialize(name, value, {
-    sameSite: 'strict',
-    ...options,
-  }))
 
 export const useResolveTranslatable = (locale = LOCALE_DEFAULT) => {
   return (translatable: Translatable) =>

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -7,9 +7,13 @@ import { defineNuxtPlugin, useCookie } from '#imports'
 import moduleOptions from '#build/cookie-control-options'
 
 export default defineNuxtPlugin((_nuxtApp) => {
-  const cookieIsConsentGiven = useCookie(moduleOptions.cookieNameIsConsentGiven)
+  const cookieIsConsentGiven = useCookie(
+    moduleOptions.cookieNameIsConsentGiven,
+    moduleOptions.cookieOptions
+  )
   const cookieCookiesEnabledIds = useCookie(
-    moduleOptions.cookieNameCookiesEnabledIds
+    moduleOptions.cookieNameCookiesEnabledIds,
+    moduleOptions.cookieOptions
   ).value?.split('|')
 
   const isConsentGiven = ref<boolean | undefined>(

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -1,4 +1,5 @@
 import { Ref } from 'vue'
+import { CookieOptions } from 'nuxt/app'
 
 import en from './locale/en'
 
@@ -84,7 +85,7 @@ export interface ModuleOptions {
     necessary: Cookie[]
     optional: Cookie[]
   }
-  domain: string
+  cookieOptions: CookieOptions
   isAcceptNecessaryButtonEnabled: boolean
   isControlButtonEnabled: boolean
   isCookieIdVisible: boolean
@@ -135,6 +136,9 @@ export const DEFAULTS: Required<ModuleOptions> = {
   cookieExpiryOffsetMs: 1000 * 60 * 60 * 24 * 365, // one year
   cookieNameIsConsentGiven: 'ncc_c',
   cookieNameCookiesEnabledIds: 'ncc_e',
+  cookieOptions: {
+    path: '/',
+  },
   isAcceptNecessaryButtonEnabled: true,
   isControlButtonEnabled: true,
   isCookieIdVisible: false,
@@ -143,7 +147,6 @@ export const DEFAULTS: Required<ModuleOptions> = {
   isDashInDescriptionEnabled: true,
   isIframeBlocked: false,
   isModalForced: false,
-  domain: '',
   locales: ['en'],
   localeTexts: { en },
 }


### PR DESCRIPTION
BREAKING CHANGE: remove stale `domain` configuration option
feat: add `cookieOptions` configuration option

### 📚 Description

<!--
  Describe your changes in detail.
  Why is this change required? What problem does it solve?
  If it resolves an open issue, please link to the issue here. For example "Resolves #1337"
-->

This PR addresses the issue described in #105.

It cleans up the cookie creation code to fully use nuxt's [useCookie](https://nuxt.com/docs/api/composables/use-cookie) where applicable, and allows passing options to useCookie.
Cookie options defaults to setting the path to "/" to be consistent with versions up to `5.9.2`.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commmits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format
- [x] The PR's title follows the Conventional Commit format
