### PR TITLE
fix: export types

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -60,7 +60,7 @@ export default defineNuxtModule<ModuleOptions>({
       filename: 'cookie-control-options.ts',
       write: true,
       getContents: () =>
-        `import { ModuleOptions } from '../../src/runtime/types'\n\nexport default ${JSON.stringify(
+        `import { ModuleOptions } from '#cookie-control/types'\n\nexport default ${JSON.stringify(
           moduleOptions,
           undefined,
           2,

--- a/src/runtime/plugin.d.ts
+++ b/src/runtime/plugin.d.ts
@@ -1,4 +1,4 @@
-import { State } from '../src/runtime/types'
+import { State } from './types'
 
 declare module '#app' {
   interface NuxtApp {


### PR DESCRIPTION
### 📚 Description

Some types are currently not exported as they should to be readable by downstream projects.

### 📝 Checklist

- [x] All commits follow the Conventional Commit format
- [x] The PR's title follows the Conventional Commit format
