### PR TITLE
fix(components): do not add show all optional cookies as enabled when `isIframeBlocked` is enabled

### DIFF
--- a/src/runtime/components/CookieControl.vue
+++ b/src/runtime/components/CookieControl.vue
@@ -341,14 +341,6 @@ onBeforeMount(() => {
     setCssVariables(variables)
   }
 
-  if (cookieIsConsentGiven.value === allCookieIdsString) {
-    for (const cookieOptional of moduleOptions.cookies.optional) {
-      if (moduleOptions.isIframeBlocked) {
-        localCookiesEnabled.value.push(cookieOptional)
-      }
-    }
-  }
-
   if (moduleOptions.isModalForced && !isConsentGiven.value) {
     isModalActive.value = true
   }


### PR DESCRIPTION
### 📚 Description

Resolves https://github.com/dargmuesli/nuxt-cookie-control/issues/115

### 📝 Checklist

- [x] All commits follow the Conventional Commit format
- [x] The PR's title follows the Conventional Commit format
