### PR TITLE
fix(package): export runtime for `require`

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     },
     "./runtime/*": {
       "import": "./dist/runtime/*.mjs",
+      "require": "./dist/runtime/*.mjs",
       "types": "./dist/runtime/*.d.ts"
     }
   },


### PR DESCRIPTION
### 📚 Description

Add a missing export to workaround `jiti` import.

### 📝 Checklist

- [x] All commits follow the Conventional Commit format
- [x] The PR's title follows the Conventional Commit format
