### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/src/runtime/components/CookieControl.vue
+++ b/src/runtime/components/CookieControl.vue
@@ -192,7 +192,7 @@
 <script setup lang="ts">
 import { ref, computed, onBeforeMount, watch } from 'vue'
 
-import { useNuxtApp } from '#app'
+import { useNuxtApp } from '#imports'
 
 import {
   type Cookie,

--- a/src/runtime/components/CookieControl.vue
+++ b/src/runtime/components/CookieControl.vue
@@ -192,8 +192,6 @@
 <script setup lang="ts">
 import { ref, computed, onBeforeMount, watch } from 'vue'
 
-import { useNuxtApp } from '#imports'
-
 import {
   type Cookie,
   CookieType,
@@ -209,7 +207,7 @@ import {
 } from '../methods'
 
 import setCssVariables from '#cookie-control/set-vars'
-import { useCookieControl, useCookie } from '#imports'
+import { useCookieControl, useCookie, useNuxtApp } from '#imports'
 
 export interface Props {
   locale?: Locale

--- a/src/runtime/components/CookieIframe.vue
+++ b/src/runtime/components/CookieIframe.vue
@@ -21,7 +21,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 
-import { useNuxtApp } from '#app'
+import { useNuxtApp } from '#imports'
 
 import type { Cookie } from '../types'
 

--- a/src/runtime/components/CookieIframe.vue
+++ b/src/runtime/components/CookieIframe.vue
@@ -21,11 +21,9 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 
-import { useNuxtApp } from '#imports'
-
 import type { Cookie } from '../types'
 
-import { useCookieControl } from '#imports'
+import { useNuxtApp, useCookieControl } from '#imports'
 
 const { cookiesEnabled, isModalActive, moduleOptions } = useCookieControl()
 const nuxtApp = useNuxtApp()


### PR DESCRIPTION
### 📚 Description

This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commmits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [ ] All commits follow the Conventional Commit format
- [ ] The PR's title follows the Conventional Commit format
