### PR TITLE
feat(module)!: require cookie id

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,8 +206,7 @@ Every property that includes a `{ en: ... }` value is a translatable property th
   description: {
     en: 'This cookie stores preferences.'
   },
-  id: 'p', // if unset, `getCookieId(cookie)` returns the cookie's slugified name instead, which e.g. is used to fill the state's `enabledCookieIds` list
-  // use a short cookie id to save bandwidth!
+  id: 'p', // use a short cookie id to save bandwidth and prefixes to separate
   name: {
     en: 'Preferences' // you always have to specify a cookie name (in English)
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   ],
   "dependencies": {
     "@nuxt/kit": "^3.8.0",
-    "@sindresorhus/slugify": "^2.2.1",
     "css-vars-ponyfill": "^2.4.8",
     "string-replace-loader": "^3.1.0"
   },

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -22,6 +22,7 @@ export default defineNuxtConfig({
             de: 'Dieser Cookie tut etwas.',
             en: 'This cookie does something very very very very very very very long.',
           },
+          id: 'n',
           name: {
             de: 'Notwendiger Cookie',
             en: 'Necessary Cookie',
@@ -31,7 +32,7 @@ export default defineNuxtConfig({
       ],
       optional: [
         {
-          id: 'op',
+          id: 'o',
           name: 'Optional Cookie',
           links: {
             'https://example.com': 'Privacy Policy',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       '@nuxt/kit':
         specifier: 3.9.0
         version: 3.9.0(rollup@3.29.4)
-      '@sindresorhus/slugify':
-        specifier: ^2.2.1
-        version: 2.2.1
       css-vars-ponyfill:
         specifier: ^2.4.8
         version: 2.4.8
@@ -1860,21 +1857,6 @@ packages:
   /@sindresorhus/merge-streams@1.0.0:
     resolution: {integrity: sha512-rUV5WyJrJLoloD4NDN1V1+LDMDWOa4OTsT4yYJwQNpTU6FWxkxHpL7eu4w+DmiH8x/EAM1otkPE1+LaspIbplw==}
     engines: {node: '>=18'}
-
-  /@sindresorhus/slugify@2.2.1:
-    resolution: {integrity: sha512-MkngSCRZ8JdSOCHRaYd+D01XhvU3Hjy6MGl06zhOk614hp9EOAp5gIkBeQg7wtmxpitU6eAL4kdiRMcJa2dlrw==}
-    engines: {node: '>=12'}
-    dependencies:
-      '@sindresorhus/transliterate': 1.6.0
-      escape-string-regexp: 5.0.0
-    dev: false
-
-  /@sindresorhus/transliterate@1.6.0:
-    resolution: {integrity: sha512-doH1gimEu3A46VX6aVxpHTeHrytJAG6HgdxntYnCFiIFHEM/ZGpG8KiZGBChchjQmG0XFIBL552kBTjVcMZXwQ==}
-    engines: {node: '>=12'}
-    dependencies:
-      escape-string-regexp: 5.0.0
-    dev: false
 
   /@trysound/sax@0.2.0:
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}

--- a/src/module.ts
+++ b/src/module.ts
@@ -72,6 +72,7 @@ export default defineNuxtModule<ModuleOptions>({
 const blockIframes = (moduleOptions: ModuleOptions) => {
   if (moduleOptions.isIframeBlocked) {
     const isIframeBlocked = {
+      id: 'ncc_f',
       name: 'functional',
     }
 

--- a/src/runtime/components/CookieControl.vue
+++ b/src/runtime/components/CookieControl.vue
@@ -95,7 +95,7 @@
                             type="checkbox"
                             :checked="
                               getCookieIds(localCookiesEnabled).includes(
-                                getCookieId(cookie),
+                                cookie.id,
                               )
                             "
                             @change="toogleCookie(cookie)"
@@ -125,7 +125,7 @@
                               {{
                                 'IDs: ' +
                                 cookie.targetCookieIds
-                                  .map((id: string) => `"${id}"`)
+                                  .map((id) => `"${id}"`)
                                   .join(', ')
                               }}
                             </span>
@@ -200,7 +200,6 @@ import {
 } from '../types'
 import {
   getAllCookieIdsString,
-  getCookieId,
   getCookieIds,
   removeCookie,
   resolveTranslatable,
@@ -266,7 +265,7 @@ const acceptPartial = () => {
     cookiesOptionalEnabled: [
       ...moduleOptions.cookies.necessary,
       ...moduleOptions.cookies.optional,
-    ].filter((cookie) => localCookiesEnabledIds.includes(getCookieId(cookie))),
+    ].filter((cookie) => localCookiesEnabledIds.includes(cookie.id)),
   })
 }
 const decline = () => {
@@ -325,9 +324,7 @@ const toggleButton = ($event: MouseEvent) => {
   )?.click()
 }
 const toogleCookie = (cookie: Cookie) => {
-  const cookieIndex = getCookieIds(localCookiesEnabled.value).indexOf(
-    getCookieId(cookie),
-  )
+  const cookieIndex = getCookieIds(localCookiesEnabled.value).indexOf(cookie.id)
 
   if (cookieIndex < 0) {
     localCookiesEnabled.value.push(cookie)

--- a/src/runtime/methods.ts
+++ b/src/runtime/methods.ts
@@ -1,5 +1,3 @@
-import slugify from '@sindresorhus/slugify'
-
 import { LOCALE_DEFAULT } from './constants'
 import type { Cookie, ModuleOptions, Translatable } from './types'
 
@@ -11,11 +9,8 @@ export const getAllCookieIdsString = (moduleOptions: ModuleOptions) =>
     ...moduleOptions.cookies.optional,
   ]).join('')
 
-export const getCookieId = (cookie: Cookie) =>
-  cookie.id || slugify(resolveTranslatable(cookie.name))
-
 export const getCookieIds = (cookies: Cookie[]) =>
-  cookies.map((cookie) => getCookieId(cookie))
+  cookies.map((cookie) => cookie.id)
 
 export const removeCookie = (name: string) =>
   useCookie(name, { expires: new Date(0) })

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -2,7 +2,7 @@ import { ref } from 'vue'
 
 import type { Plugin } from '#app'
 
-import { getAllCookieIdsString, getCookieId } from './methods'
+import { getAllCookieIdsString } from './methods'
 import type { Cookie, State } from './types'
 
 import { defineNuxtPlugin, useCookie } from '#imports'
@@ -28,10 +28,10 @@ const plugin: Plugin<{ cookies: State }> = defineNuxtPlugin((_nuxtApp) => {
       ? undefined
       : [
           ...moduleOptions.cookies.necessary.filter((cookieNecessary) =>
-            cookieCookiesEnabledIds.includes(getCookieId(cookieNecessary)),
+            cookieCookiesEnabledIds.includes(cookieNecessary.id),
           ),
           ...moduleOptions.cookies.optional.filter((cookieOptional) =>
-            cookieCookiesEnabledIds.includes(getCookieId(cookieOptional)),
+            cookieCookiesEnabledIds.includes(cookieOptional.id),
           ),
         ],
   )

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -46,7 +46,7 @@ export enum CookieType {
 
 export interface Cookie {
   description?: Translatable
-  id?: string
+  id: string
   name: Translatable
   links?: Record<string, string | null>
   src?: string


### PR DESCRIPTION
### 📚 Description

When no cookie id was given, the cookie id was set to the slugified version of the cookie name. This lead to a large bundle size and made it less obvious that a short cookie id would save bandwidth. Therefore the slugification along with the `getCookieId` method is removed and it is now required to set cookie ids manually, improving the project's performance.

This project's playground client bundle is not 14% smaller.

### 📝 Checklist

- [x] All commits follow the Conventional Commit format
- [x] The PR's title follows the Conventional Commit format
