### PR TITLE
chore: indicate compatibility with new v4 major

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -28,7 +28,7 @@ export default defineNuxtModule<ModuleOptions>({
     name,
     version,
     configKey: CONFIG_KEY,
-    compatibility: { nuxt: '^3.0.0' },
+    compatibility: { nuxt: '>=3.0.0' },
   },
   defaults: DEFAULTS,
   hooks: {


### PR DESCRIPTION
### 📚 Description

With Nuxt 4 on the horizon, this updates the module compatibility definition to allow it to be installed on Nuxt v4. (Otherwise Nuxt will indicate the module might not be compatible.)

When Nuxt v4 comes out then you might decide or need to make breaking changes in this module and release a new major, but hopefully the migration should be smoother. 🙏 

👉 You can follow this and other changes in https://github.com/nuxt/nuxt/issues/27613 - please feel free to provide feedback as well!

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commmits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [ ] All commits follow the Conventional Commit format
- [ ] The PR's title follows the Conventional Commit format
