### PR TITLE
chore(types): inject plugin types

### DIFF
--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -173,3 +173,15 @@ export interface State {
   locale: Ref<Locale>
   moduleOptions: ModuleOptions
 }
+
+declare module '#app' {
+  interface NuxtApp {
+    $cookies: State
+  }
+}
+
+declare module 'vue' {
+  interface ComponentCustomProperties {
+    $cookies: State
+  }
+}


### PR DESCRIPTION
### 📚 Description

<!--
  Describe your changes in detail.
  Why is this change required? What problem does it solve?
  If it resolves an open issue, please link to the issue here. For example "Resolves #1337"
-->

This PR adds plugin type declaration injection, this also to enables ctrl+click to open `$cookies` definition when used with the `useNuxtApp` composable. I've seen other modules type their plugins this way too.

Injecting plugin types also avoids unknown types on `vue-tsc` checks.

- Reference: https://nuxt.com/docs/guide/directory-structure/plugins#typing-plugins

Solves ci errors on #220 


### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commmits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format
- [x] The PR's title follows the Conventional Commit format
