### PR TITLE
fix(types): handle non-null assertion

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -4,6 +4,7 @@ export default defineNuxtConfig({
       title: 'Playground',
     },
   },
+  compatibilityDate: '2024-04-03',
   modules: ['@dargmuesli/nuxt-cookie-control'],
   typescript: {
     includeWorkspace: true,

--- a/src/runtime/components/CookieControl.vue
+++ b/src/runtime/components/CookieControl.vue
@@ -377,7 +377,11 @@ watch(
 
         const script = document.createElement('script')
         script.src = cookieEnabled.src
-        document.getElementsByTagName('head')[0]!.appendChild(script)
+
+        const headElement = document.getElementsByTagName('head')[0]
+        if (!headElement) return
+
+        headElement.appendChild(script)
       }
     } else {
       cookieCookiesEnabledIds.value = undefined

--- a/src/runtime/components/CookieControl.vue
+++ b/src/runtime/components/CookieControl.vue
@@ -377,7 +377,7 @@ watch(
 
         const script = document.createElement('script')
         script.src = cookieEnabled.src
-        document.getElementsByTagName('head')[0].appendChild(script)
+        document.getElementsByTagName('head')[0]!.appendChild(script)
       }
     } else {
       cookieCookiesEnabledIds.value = undefined

--- a/src/runtime/set-vars/native.ts
+++ b/src/runtime/set-vars/native.ts
@@ -1,5 +1,8 @@
 export default function (variables: Record<string, string>) {
   for (const cssVar in variables) {
-    document.documentElement.style.setProperty(`--${cssVar}`, variables[cssVar])
+    document.documentElement.style.setProperty(
+      `--${cssVar}`,
+      variables[cssVar] ?? null,
+    )
   }
 }


### PR DESCRIPTION
### 📚 Description

<!--
  Describe your changes in detail.
  Why is this change required? What problem does it solve?
  If it resolves an open issue, please link to the issue here. For example "Resolves #1337"
-->

Hello!, I started type-checking one of my projects which makes use of this module and I noticed that my `vue-tsc --noEmit` command complains about two type-check errors coming from this module, the 1st one is about plugin types not being injected (I opened #221 solving the issue) and the 2nd one indicates that line below is possibly `undefined`

https://github.com/dargmuesli/nuxt-cookie-control/blob/a54e6cb0edde969b54dc4268d3a426d6f13f5d99/src/runtime/components/CookieControl.vue#L380

This PR suggests that if we know that the head array will never be `undefined`, then add a non-null assertion (`!`) to indicate it to the ts-plugin

### Reproduction

I created a minimal reproduction here: https://stackblitz.com/edit/github-rdlsvu-jmfrqy?file=package.json

1. Click on the link to open the reproduction and wait for the container to run the commands
2. Look for the error in the terminal

![image](https://github.com/dargmuesli/nuxt-cookie-control/assets/16264115/b5e18f62-96cc-494d-a7f5-0c1f45bdb691)

---

Adding the non-null assertion seems to work, I tested it locally on my vscode, no errors showing up
![image](https://github.com/dargmuesli/nuxt-cookie-control/assets/16264115/a886de17-2d36-4640-b870-8af354c255ee)



### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commmits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format
- [x] The PR's title follows the Conventional Commit format
