### PR TITLE
perf(components): remove client-only restriction

### DIFF
--- a/src/runtime/components/CookieControl.vue
+++ b/src/runtime/components/CookieControl.vue
@@ -1,201 +1,197 @@
 <template>
-  <client-only>
-    <aside class="cookieControl">
-      <transition :name="`cookieControl__Bar--${moduleOptions.barPosition}`">
-        <div
-          v-if="!isConsentGiven && !moduleOptions.isModalForced"
-          :class="`cookieControl__Bar cookieControl__Bar--${moduleOptions.barPosition}`"
-        >
-          <div class="cookieControl__BarContainer">
-            <div>
-              <slot name="bar">
-                <h2 v-text="localeStrings?.bannerTitle" />
-                <p v-text="localeStrings?.bannerDescription" />
-              </slot>
-            </div>
-            <div class="cookieControl__BarButtons">
-              <button @click="accept()" v-text="localeStrings?.accept" />
-              <button
-                v-if="moduleOptions.isAcceptNecessaryButtonEnabled"
-                @click="decline()"
-                v-text="localeStrings?.decline"
-              />
-              <button
-                @click="isModalActive = true"
-                v-text="localeStrings?.manageCookies"
-              />
-            </div>
+  <aside class="cookieControl">
+    <transition :name="`cookieControl__Bar--${moduleOptions.barPosition}`">
+      <div
+        v-if="!isConsentGiven && !moduleOptions.isModalForced"
+        :class="`cookieControl__Bar cookieControl__Bar--${moduleOptions.barPosition}`"
+      >
+        <div class="cookieControl__BarContainer">
+          <div>
+            <slot name="bar">
+              <h2 v-text="localeStrings?.bannerTitle" />
+              <p v-text="localeStrings?.bannerDescription" />
+            </slot>
+          </div>
+          <div class="cookieControl__BarButtons">
+            <button @click="accept()" v-text="localeStrings?.accept" />
+            <button
+              v-if="moduleOptions.isAcceptNecessaryButtonEnabled"
+              @click="decline()"
+              v-text="localeStrings?.decline"
+            />
+            <button
+              @click="isModalActive = true"
+              v-text="localeStrings?.manageCookies"
+            />
           </div>
         </div>
-      </transition>
-      <button
-        v-if="moduleOptions.isControlButtonEnabled && isConsentGiven"
-        aria-label="Cookie control"
-        class="cookieControl__ControlButton"
-        data-testid="nuxt-cookie-control-control-button"
-        @click="isModalActive = true"
+      </div>
+    </transition>
+    <button
+      v-if="moduleOptions.isControlButtonEnabled && isConsentGiven"
+      aria-label="Cookie control"
+      class="cookieControl__ControlButton"
+      data-testid="nuxt-cookie-control-control-button"
+      @click="isModalActive = true"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+        <path
+          fill="currentColor"
+          d="M510.52 255.82c-69.97-.85-126.47-57.69-126.47-127.86-70.17 0-127-56.49-127.86-126.45-27.26-4.14-55.13.3-79.72 12.82l-69.13 35.22a132.221 132.221 0 00-57.79 57.81l-35.1 68.88a132.645 132.645 0 00-12.82 80.95l12.08 76.27a132.521 132.521 0 0037.16 72.96l54.77 54.76a132.036 132.036 0 0072.71 37.06l76.71 12.15c27.51 4.36 55.7-.11 80.53-12.76l69.13-35.21a132.273 132.273 0 0057.79-57.81l35.1-68.88c12.56-24.64 17.01-52.58 12.91-79.91zM176 368c-17.67 0-32-14.33-32-32s14.33-32 32-32 32 14.33 32 32-14.33 32-32 32zm32-160c-17.67 0-32-14.33-32-32s14.33-32 32-32 32 14.33 32 32-14.33 32-32 32zm160 128c-17.67 0-32-14.33-32-32s14.33-32 32-32 32 14.33 32 32-14.33 32-32 32z"
+        />
+      </svg>
+    </button>
+    <transition name="cookieControl__Modal">
+      <div
+        v-if="isModalActive"
+        class="cookieControl__Modal"
+        @click.self="onModalClick"
       >
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-          <path
-            fill="currentColor"
-            d="M510.52 255.82c-69.97-.85-126.47-57.69-126.47-127.86-70.17 0-127-56.49-127.86-126.45-27.26-4.14-55.13.3-79.72 12.82l-69.13 35.22a132.221 132.221 0 00-57.79 57.81l-35.1 68.88a132.645 132.645 0 00-12.82 80.95l12.08 76.27a132.521 132.521 0 0037.16 72.96l54.77 54.76a132.036 132.036 0 0072.71 37.06l76.71 12.15c27.51 4.36 55.7-.11 80.53-12.76l69.13-35.21a132.273 132.273 0 0057.79-57.81l35.1-68.88c12.56-24.64 17.01-52.58 12.91-79.91zM176 368c-17.67 0-32-14.33-32-32s14.33-32 32-32 32 14.33 32 32-14.33 32-32 32zm32-160c-17.67 0-32-14.33-32-32s14.33-32 32-32 32 14.33 32 32-14.33 32-32 32zm160 128c-17.67 0-32-14.33-32-32s14.33-32 32-32 32 14.33 32 32-14.33 32-32 32z"
-          />
-        </svg>
-      </button>
-      <transition name="cookieControl__Modal">
-        <div
-          v-if="isModalActive"
-          class="cookieControl__Modal"
-          @click.self="onModalClick"
-        >
-          <p
-            v-if="isSaved"
-            class="cookieControl__ModalUnsaved"
-            v-text="localeStrings?.settingsUnsaved"
-          />
-          <div class="cookieControl__ModalContent">
-            <div class="cookieControl__ModalContentInner">
-              <slot name="modal" />
-              <button
-                v-if="!moduleOptions.isModalForced"
-                class="cookieControl__ModalClose"
-                @click="isModalActive = false"
-                v-text="localeStrings?.close"
-              />
-              <template v-for="cookieType in CookieType" :key="cookieType">
-                <template v-if="moduleOptions.cookies[cookieType].length">
-                  <h2
-                    v-text="
-                      localeStrings &&
-                      (cookieType === CookieType.NECESSARY
-                        ? localeStrings.cookiesNecessary
-                        : localeStrings.cookiesOptional)
-                    "
-                  />
-                  <ul>
-                    <li
-                      v-for="cookie in moduleOptions.cookies[cookieType]"
-                      :key="cookie.id"
-                    >
-                      <slot name="cookie" v-bind="{ cookie }">
-                        <div class="cookieControl__ModalInputWrapper">
-                          <input
+        <p
+          v-if="isSaved"
+          class="cookieControl__ModalUnsaved"
+          v-text="localeStrings?.settingsUnsaved"
+        />
+        <div class="cookieControl__ModalContent">
+          <div class="cookieControl__ModalContentInner">
+            <slot name="modal" />
+            <button
+              v-if="!moduleOptions.isModalForced"
+              class="cookieControl__ModalClose"
+              @click="isModalActive = false"
+              v-text="localeStrings?.close"
+            />
+            <template v-for="cookieType in CookieType" :key="cookieType">
+              <template v-if="moduleOptions.cookies[cookieType].length">
+                <h2
+                  v-text="
+                    localeStrings &&
+                    (cookieType === CookieType.NECESSARY
+                      ? localeStrings.cookiesNecessary
+                      : localeStrings.cookiesOptional)
+                  "
+                />
+                <ul>
+                  <li
+                    v-for="cookie in moduleOptions.cookies[cookieType]"
+                    :key="cookie.id"
+                  >
+                    <slot name="cookie" v-bind="{ cookie }">
+                      <div class="cookieControl__ModalInputWrapper">
+                        <input
+                          v-if="
+                            cookieType === CookieType.NECESSARY &&
+                            cookie.name !== 'functional'
+                          "
+                          :id="resolveTranslatable(cookie.name, props.locale)"
+                          type="checkbox"
+                          disabled
+                          checked
+                        />
+                        <input
+                          v-else
+                          :id="resolveTranslatable(cookie.name, props.locale)"
+                          type="checkbox"
+                          :checked="
+                            isConsentGiven === undefined
+                              ? cookie.isPreselected
+                              : getCookieIds(localCookiesEnabled).includes(
+                                  cookie.id,
+                                )
+                          "
+                          @change="toogleCookie(cookie)"
+                        />
+                        <button @click="toggleButton($event)">
+                          {{ getName(cookie.name) }}
+                        </button>
+                        <label
+                          class="cookieControl__ModalCookieName"
+                          :for="resolveTranslatable(cookie.name, props.locale)"
+                          tabindex="0"
+                          @keydown="toggleLabel($event)"
+                        >
+                          {{ getName(cookie.name) }}
+                          <span v-if="cookie.description">
+                            {{ getDescription(cookie.description) }}
+                          </span>
+                          <span
                             v-if="
-                              cookieType === CookieType.NECESSARY &&
-                              cookie.name !== 'functional'
+                              moduleOptions.isCookieIdVisible &&
+                              cookie.targetCookieIds
                             "
-                            :id="resolveTranslatable(cookie.name, props.locale)"
-                            type="checkbox"
-                            disabled
-                            checked
-                          />
-                          <input
-                            v-else
-                            :id="resolveTranslatable(cookie.name, props.locale)"
-                            type="checkbox"
-                            :checked="
-                              isConsentGiven === undefined
-                                ? cookie.isPreselected
-                                : getCookieIds(localCookiesEnabled).includes(
-                                    cookie.id,
-                                  )
-                            "
-                            @change="toogleCookie(cookie)"
-                          />
-                          <button @click="toggleButton($event)">
-                            {{ getName(cookie.name) }}
-                          </button>
-                          <label
-                            class="cookieControl__ModalCookieName"
-                            :for="
-                              resolveTranslatable(cookie.name, props.locale)
-                            "
-                            tabindex="0"
-                            @keydown="toggleLabel($event)"
                           >
-                            {{ getName(cookie.name) }}
-                            <span v-if="cookie.description">
-                              {{ getDescription(cookie.description) }}
-                            </span>
+                            <br />
+                            {{
+                              'IDs: ' +
+                              cookie.targetCookieIds
+                                .map((id) => `"${id}"`)
+                                .join(', ')
+                            }}
+                          </span>
+                          <template
+                            v-if="Object.entries(cookie.links || {}).length"
+                          >
                             <span
-                              v-if="
-                                moduleOptions.isCookieIdVisible &&
-                                cookie.targetCookieIds
-                              "
+                              v-for="entry in Object.entries(
+                                cookie.links || {},
+                              )"
+                              :key="entry[0]"
                             >
                               <br />
-                              {{
-                                'IDs: ' +
-                                cookie.targetCookieIds
-                                  .map((id) => `"${id}"`)
-                                  .join(', ')
-                              }}
-                            </span>
-                            <template
-                              v-if="Object.entries(cookie.links || {}).length"
-                            >
-                              <span
-                                v-for="entry in Object.entries(
-                                  cookie.links || {},
-                                )"
-                                :key="entry[0]"
+                              <NuxtLink
+                                :to="entry[0]"
+                                @click="
+                                  !entry[0].toLowerCase().startsWith('http')
+                                    ? (isModalActive = false)
+                                    : null
+                                "
                               >
-                                <br />
-                                <NuxtLink
-                                  :to="entry[0]"
-                                  @click="
-                                    !entry[0].toLowerCase().startsWith('http')
-                                      ? (isModalActive = false)
-                                      : null
-                                  "
-                                >
-                                  {{ entry[1] || entry[0] }}
-                                </NuxtLink>
-                              </span>
-                            </template>
-                          </label>
-                        </div>
-                      </slot>
-                    </li>
-                  </ul>
-                </template>
+                                {{ entry[1] || entry[0] }}
+                              </NuxtLink>
+                            </span>
+                          </template>
+                        </label>
+                      </div>
+                    </slot>
+                  </li>
+                </ul>
               </template>
-              <div class="cookieControl__ModalButtons">
-                <button
-                  @click="
-                    () => {
-                      acceptPartial()
-                      isModalActive = false
-                    }
-                  "
-                  v-text="localeStrings?.save"
-                />
-                <button
-                  @click="
-                    () => {
-                      accept()
-                      isModalActive = false
-                    }
-                  "
-                  v-text="localeStrings?.acceptAll"
-                />
-                <button
-                  v-if="!moduleOptions.isModalForced"
-                  @click="
-                    () => {
-                      declineAll()
-                      isModalActive = false
-                    }
-                  "
-                  v-text="localeStrings?.declineAll"
-                />
-              </div>
+            </template>
+            <div class="cookieControl__ModalButtons">
+              <button
+                @click="
+                  () => {
+                    acceptPartial()
+                    isModalActive = false
+                  }
+                "
+                v-text="localeStrings?.save"
+              />
+              <button
+                @click="
+                  () => {
+                    accept()
+                    isModalActive = false
+                  }
+                "
+                v-text="localeStrings?.acceptAll"
+              />
+              <button
+                v-if="!moduleOptions.isModalForced"
+                @click="
+                  () => {
+                    declineAll()
+                    isModalActive = false
+                  }
+                "
+                v-text="localeStrings?.declineAll"
+              />
             </div>
           </div>
         </div>
-      </transition>
-    </aside>
-  </client-only>
+      </div>
+    </transition>
+  </aside>
 </template>
 
 <script setup lang="ts">

--- a/src/runtime/components/CookieIframe.vue
+++ b/src/runtime/components/CookieIframe.vue
@@ -1,21 +1,19 @@
 <template>
-  <ClientOnly>
-    <iframe
-      v-if="isCookieFunctionalEnabled"
-      :cookie-enabled="null"
-      v-bind="$attrs"
-    />
-    <div v-else class="cookieControl__BlockedIframe">
-      <p>
-        {{ localeStrings?.iframeBlocked }}
-        <a
-          href="#"
-          @click.prevent="isModalActive = true"
-          v-text="localeStrings?.here"
-        />
-      </p>
-    </div>
-  </ClientOnly>
+  <iframe
+    v-if="isCookieFunctionalEnabled"
+    :cookie-enabled="null"
+    v-bind="$attrs"
+  />
+  <div v-else class="cookieControl__BlockedIframe">
+    <p>
+      {{ localeStrings?.iframeBlocked }}
+      <a
+        href="#"
+        @click.prevent="isModalActive = true"
+        v-text="localeStrings?.here"
+      />
+    </p>
+  </div>
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
### 📚 Description

The client only restriction was added in 64b1a9481daf7d21d94a2585de4c7025d63c3304 but does not seem to be necessary anymore. Removing it should help with getting rid of cumulative layout shift (LCP).

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commmits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format
- [x] The PR's title follows the Conventional Commit format
