### PR TITLE
feat(component): add decline optional button and only accept necessary in modal mode

### DIFF
--- a/src/runtime/components/CookieControl.vue
+++ b/src/runtime/components/CookieControl.vue
@@ -190,6 +190,17 @@
                   v-text="localeStrings?.acceptAll"
                 />
                 <button
+                  v-if="!moduleOptions.isDeclinedOptional"
+                  type="button"
+                  @click="
+                    () => {
+                      decline()
+                      isModalActive = false
+                    }
+                  "
+                  v-text="localeStrings?.decline"
+                />
+                <button
                   v-if="!moduleOptions.isModalForced"
                   type="button"
                   @click="

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -102,9 +102,9 @@ export interface ModuleOptions {
   isCssEnabled: boolean
   isCssPonyfillEnabled: boolean
   isDashInDescriptionEnabled: boolean
+  isDeclinedOptional: boolean
   isIframeBlocked: boolean
   isModalForced: boolean
-  isDeclinedOptional: boolean
   locales: Locale[]
   localeTexts: PartialRecord<Locale, Partial<LocaleStrings>>
 }

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -104,6 +104,7 @@ export interface ModuleOptions {
   isDashInDescriptionEnabled: boolean
   isIframeBlocked: boolean
   isModalForced: boolean
+  isDeclinedOptional: boolean
   locales: Locale[]
   localeTexts: PartialRecord<Locale, Partial<LocaleStrings>>
 }
@@ -159,6 +160,7 @@ export const DEFAULTS: Required<ModuleOptions> = {
   isDashInDescriptionEnabled: true,
   isIframeBlocked: false,
   isModalForced: false,
+  isDeclinedOptional: false,
   locales: ['en'],
 
   // TODO: use Nuxt module "i18n"

--- a/src/types.ts
+++ b/src/types.ts
@@ -159,9 +159,9 @@ export const DEFAULTS: Required<ModuleOptions> = {
   isCssEnabled: true,
   isCssPonyfillEnabled: false,
   isDashInDescriptionEnabled: true,
+  isDeclinedOptional: false,
   isIframeBlocked: false,
   isModalForced: false,
-  isDeclinedOptional: false,
   locales: ['en'],
   localeTexts: { en },
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,6 +104,7 @@ export interface ModuleOptions {
   isDashInDescriptionEnabled: boolean
   isIframeBlocked: boolean
   isModalForced: boolean
+  isDeclinedOptional: boolean
   locales: Locale[]
   localeTexts: PartialRecord<Locale, Partial<LocaleStrings>>
 }
@@ -160,6 +161,7 @@ export const DEFAULTS: Required<ModuleOptions> = {
   isDashInDescriptionEnabled: true,
   isIframeBlocked: false,
   isModalForced: false,
+  isDeclinedOptional: false,
   locales: ['en'],
   localeTexts: { en },
 }


### PR DESCRIPTION
### 📚 Description

<!--
  Describe your changes in detail.
  Why is this change required? What problem does it solve?
  If it resolves an open issue, please link to the issue here. For example "Resolves #1337"
-->

This PR adds the possibility to display a button in forced modal mode that only rejects the optional cookies, like in the banner. It is configurable via boolean in the nuxt config file.


### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commmits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format
- [x] The PR's title follows the Conventional Commit format
