### PR TITLE
ci: remove corepack workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup package manager
-        run: |
-          npm install -g --force corepack@latest # TODO: remove (https://github.com/nodejs/corepack/issues/612)
-          corepack enable
+        run: corepack enable
 
       - name: Setup Node
         uses: actions/setup-node@v4.3.0


### PR DESCRIPTION
### 📚 Description

Workaround is no longer needed.

Waiting for:
- Node v20.19.0 or newer in MacOS runner image

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commmits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format
- [x] The PR's title follows the Conventional Commit format
