### PR TITLE
refactor(components): rename feedback functions to clarify privacy impact

### DIFF
--- a/src/runtime/components/CookieControl.vue
+++ b/src/runtime/components/CookieControl.vue
@@ -16,13 +16,13 @@
             <div class="cookieControl__BarButtons">
               <button
                 type="button"
-                @click="accept()"
+                @click="acceptAll()"
                 v-text="localeStrings?.accept"
               />
               <button
                 v-if="moduleOptions.isAcceptNecessaryButtonEnabled"
                 type="button"
-                @click="decline()"
+                @click="acceptNecessary()"
                 v-text="localeStrings?.decline"
               />
               <button
@@ -183,7 +183,7 @@
                   type="button"
                   @click="
                     () => {
-                      accept()
+                      acceptNecessary()
                       isModalActive = false
                     }
                   "
@@ -194,7 +194,7 @@
                   type="button"
                   @click="
                     () => {
-                      declineAll()
+                      acceptNone()
                       isModalActive = false
                     }
                   "
@@ -270,7 +270,7 @@ const isSaved = computed(
 const localeStrings = computed(() => moduleOptions.localeTexts[locale])
 
 // methods
-const accept = () => {
+const acceptAll = () => {
   setCookies({
     isConsentGiven: true,
     cookiesOptionalEnabled: moduleOptions.cookies.optional,
@@ -287,13 +287,13 @@ const acceptPartial = () => {
     ].filter((cookie) => localCookiesEnabledIds.includes(cookie.id)),
   })
 }
-const decline = () => {
+const acceptNecessary = () => {
   setCookies({
     isConsentGiven: true,
     cookiesOptionalEnabled: moduleOptions.cookies.necessary,
   })
 }
-const declineAll = () => {
+const acceptNone = () => {
   setCookies({
     isConsentGiven: false,
     cookiesOptionalEnabled: [],
@@ -441,8 +441,8 @@ watch(
 init()
 
 defineExpose({
-  accept,
+  accept: acceptAll,
   acceptPartial,
-  decline,
+  decline: acceptNecessary,
 })
 </script>


### PR DESCRIPTION
### 📚 Description

"decline" could suggest that no cookies are set at all, "accept necessary" makes it more clear what's actually happening.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commmits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] The PR's title follows the Conventional Commit format
