### PR TITLE
fix: call `acceptAll()` instead of `acceptNecessary()` when clicking "Accept All"

### DIFF
--- a/src/runtime/components/CookieControl.vue
+++ b/src/runtime/components/CookieControl.vue
@@ -183,7 +183,7 @@
                   type="button"
                   @click="
                     () => {
-                      acceptNecessary()
+                      acceptAll()
                       isModalActive = false
                     }
                   "


### PR DESCRIPTION
### 📚 Description

Fixes
- https://github.com/dargmuesli/nuxt-cookie-control/issues/275

---

Clicking "Accept All" in the consent modal will only set necessary cookies.

In this [renaming commit](https://github.com/dargmuesli/nuxt-cookie-control/commit/6a78a7d643b5fe0e21abd8fa9eb8d02607fc0010) the method names were changed, but the "Accept All" button was assigned with the `acceptNecessary()` method instead of `acceptAll()`.

https://github.com/dargmuesli/nuxt-cookie-control/blob/7b2c09ac772a493769b57b0084979e95d710dcf7/src/runtime/components/CookieControl.vue#L182-L191

This PR changes the called method from `acceptNecessary()` to `acceptAll()` when clicking "Accept All".

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commmits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [ ] The PR's title follows the Conventional Commit format
