### PR TITLE
fix: save `isPreselected` on "Save"

### DIFF
--- a/src/runtime/components/CookieControl.vue
+++ b/src/runtime/components/CookieControl.vue
@@ -104,11 +104,9 @@
                             :id="resolveTranslatable(cookie.name, locale)"
                             type="checkbox"
                             :checked="
-                              isConsentGiven === undefined
-                                ? cookie.isPreselected
-                                : getCookieIds(localCookiesEnabled).includes(
-                                    cookie.id,
-                                  )
+                              getCookieIds(localCookiesEnabled).includes(
+                                cookie.id,
+                              )
                             "
                             @change="toggleCookie(cookie)"
                           />
@@ -244,7 +242,13 @@ const nuxtApp = useNuxtApp()
 
 // data
 const expires = new Date(Date.now() + moduleOptions.cookieExpiryOffsetMs)
-const localCookiesEnabled = ref([...(cookiesEnabled.value || [])])
+const preselectedCookies = moduleOptions.cookies[CookieType.OPTIONAL].filter(
+  (cookie) => cookie.isPreselected,
+)
+const localCookiesEnabled = ref([
+  ...(cookiesEnabled.value ||
+    (isConsentGiven.value === undefined ? preselectedCookies : [])),
+])
 const allCookieIdsString = getAllCookieIdsString(moduleOptions)
 const cookieIsConsentGiven = useCookie(moduleOptions.cookieNameIsConsentGiven, {
   expires,

--- a/src/runtime/components/CookieControl.vue
+++ b/src/runtime/components/CookieControl.vue
@@ -110,7 +110,7 @@
                                     cookie.id,
                                   )
                             "
-                            @change="toogleCookie(cookie)"
+                            @change="toggleCookie(cookie)"
                           />
                           <button type="button" @click="toggleButton($event)">
                             {{ getName(cookie.name) }}
@@ -342,7 +342,7 @@ const toggleButton = ($event: MouseEvent) => {
       ?.nextSibling as HTMLLabelElement | null
   )?.click()
 }
-const toogleCookie = (cookie: Cookie) => {
+const toggleCookie = (cookie: Cookie) => {
   const cookieIndex = getCookieIds(localCookiesEnabled.value).indexOf(cookie.id)
 
   if (cookieIndex < 0) {


### PR DESCRIPTION
Fixes:
- https://github.com/dargmuesli/nuxt-cookie-control/issues/278

### 📚 Description

Clicking "Save" in the modal will not save preselected cookies, even though the checkbox is checked.

In this PR, instead of only checking the checkbox, cookies with `isPreselected: true` will be directly loaded into `localCookiesEnabled` which controls both checkbox state **and** which cookies will be saved on "Save".

### 📝 Checklist

- [ ] The PR's title follows the Conventional Commit format
