### PR TITLE
feat(locale): add pt-BR locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ![nuxt-cookie-control](https://drive.google.com/a/broj42.com/uc?id=19sFguJo7SKUvmH4xu9DhK9ZXzR6oWLX8)
 
-✅ Translated for: ar, az, be, bg, ca, cs, da, de, en, es, fi, fr, hr, hu, id, it, ja, km, ko, lt, nl, no, oc, pt, pl, ro, rs, ru, sk, sl, sv, tr, uk and zh-CN
+✅ Translated for: ar, az, be, bg, ca, cs, da, de, en, es, fi, fr, hr, hu, id, it, ja, km, ko, lt, nl, no, oc, pt-BR, pt, pl, ro, rs, ru, sk, sl, sv, tr, uk and zh-CN
 
 ✅ Vue 3 support
 

--- a/src/runtime/locale/index.ts
+++ b/src/runtime/locale/index.ts
@@ -21,6 +21,7 @@ import lt from './lt'
 import nl from './nl'
 import no from './no'
 import oc from './oc'
+import ptBR from './pt-BR'
 import pt from './pt'
 import pl from './pl'
 import ro from './ro'
@@ -57,6 +58,7 @@ export const locales = [
   nl,
   no,
   oc,
+  ptBR,
   pt,
   pl,
   ro,

--- a/src/runtime/locale/pt-BR.ts
+++ b/src/runtime/locale/pt-BR.ts
@@ -1,0 +1,21 @@
+import type { LocaleStrings } from '#cookie-control/types'
+
+export default {
+  accept: 'Aceitar',
+  acceptAll: 'Aceitar todos',
+  bannerDescription:
+    'Utilizamos cookies próprios e de terceiros para permitir a navegação no site e analisar o seu uso, de modo a melhorar os serviços que oferecemos. Ao continuar navegando, consideramos que você aceita a utilização de cookies.',
+  bannerTitle: 'Cookies',
+  close: 'Fechar',
+  cookiesFunctional: 'Cookies funcionais',
+  cookiesNecessary: 'Cookies necessários',
+  cookiesOptional: 'Cookies opcionais',
+  decline: 'Aceitar apenas os necessários',
+  declineAll: 'Rejeitar todos',
+  here: 'aqui',
+  iframeBlocked:
+    'Para visualizar este conteúdo, por favor, ative os cookies funcionais.',
+  manageCookies: 'Gerenciar cookies',
+  save: 'Salvar',
+  settingsUnsaved: 'Você tem alterações não salvas',
+} as LocaleStrings

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -27,6 +27,7 @@ export type Locale =
   | 'nl'
   | 'no'
   | 'oc'
+  | 'pt-BR'
   | 'pt'
   | 'pl'
   | 'ro'


### PR DESCRIPTION
### 📚 Description

I added the 'pt-BR' (Brazilian Portuguese) locale. This is necessary because Brazilian Portuguese has significant differences from European Portuguese ('pt'), and it is widely supported in the Nuxt UI.

### 📝 Checklist

- [x] The PR's title follows the Conventional Commit format
